### PR TITLE
LxMERT Integration with DroneVQA Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__/
 
 # Ignore MacOS DS Store
 .DS_Store
+Application/lxmert_best_model.pth

--- a/Application/VQAInteractionScreen.py
+++ b/Application/VQAInteractionScreen.py
@@ -195,6 +195,10 @@ class VQAInteractionScreen(QWidget):
             model_index = 1
             model = self.models[model_index]
             worker = Worker(predictLxmert, model[0], model[1], model[2], model[3], model[4], question, image)
+        elif self.ui.radioButton_LxmertFineTuned.isChecked():
+            model_index = 2
+            model = self.models[model_index]
+            worker = Worker(predictLxmert, model[0], model[1], model[2], model[3], model[4], question, image)
 
         def completed():
             # Set ask button active and change text/color back to user ask prompt

--- a/Application/VQAInteractionScreen.ui
+++ b/Application/VQAInteractionScreen.ui
@@ -1286,7 +1286,7 @@ padding: 5px;
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QRadioButton" name="LxmertFineTuned">
+       <widget class="QRadioButton" name="radioButton_LxmertFineTuned">
         <property name="text">
          <string>LXMERT (Fine Tuned)</string>
         </property>
@@ -1587,7 +1587,7 @@ padding: 4px 0;
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>20</y>
+      <y>10</y>
       <width>721</width>
       <height>431</height>
      </rect>

--- a/Application/VQAInteractionScreen.ui
+++ b/Application/VQAInteractionScreen.ui
@@ -1244,21 +1244,18 @@ padding: 5px;
     <set>Qt::AlignCenter</set>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="topMargin">
+     <number>5</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
     <item>
-     <layout class="QGridLayout" name="gridLayout_Models">
-      <item row="0" column="1">
-       <widget class="QRadioButton" name="radioButton_LxmertBase">
-        <property name="font">
-         <font>
-          <family>Arial</family>
-         </font>
-        </property>
-        <property name="text">
-         <string>LXMERT (Base)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
+     <layout class="QGridLayout" name="gridLayout_Models" columnstretch="0,0">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <item row="1" column="0">
        <widget class="QRadioButton" name="radioButton_ViltBase">
         <property name="font">
          <font>
@@ -1273,6 +1270,32 @@ padding: 5px;
         </property>
         <property name="checked">
          <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QRadioButton" name="radioButton_LxmertBase">
+        <property name="font">
+         <font>
+          <family>Arial</family>
+         </font>
+        </property>
+        <property name="text">
+         <string>LXMERT (Base)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="LxmertFineTuned">
+        <property name="text">
+         <string>LXMERT (Fine Tuned)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="radioButton">
+        <property name="text">
+         <string>ViLT (Fine Tuned)</string>
         </property>
        </widget>
       </item>
@@ -1412,8 +1435,8 @@ padding: 4px 0;
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>612</width>
-         <height>96</height>
+         <width>594</width>
+         <height>88</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/Application/application.py
+++ b/Application/application.py
@@ -33,6 +33,9 @@ def ImportGlobalModules(loadScreen):
     global setupLxmertTransformer
     from utils import setupLxmertTransformer
 
+    loadScreen.updateLoadStatus(percentComplete=55, statusText="Importing setupLxmertTransformer_finetuned")
+    global setupLxmertTransformer_finetuned
+    from utils import setupLxmertTransformer_finetuned
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
@@ -74,8 +77,10 @@ if __name__ == "__main__":
     models = []
     loadScreen.updateLoadStatus(percentComplete=60, statusText="Initializing Vilt model\nThis step will take longer the first time this application loads.")
     models.append((setupViltTransformer()))
-    loadScreen.updateLoadStatus(percentComplete=80, statusText="Initializing both LxMERT models\nThis step will take longer the first time this application loads.")
+    loadScreen.updateLoadStatus(percentComplete=80, statusText="Initializing base LxMERT model\nThis step will take longer the first time this application loads.")
     models.append((setupLxmertTransformer()))
+    loadScreen.updateLoadStatus(percentComplete=90, statusText="Initializing fine-tuned LxMERT model\nThis step will take longer the first time this application loads.")
+    models.append((setupLxmertTransformer_finetuned()))
     loadScreen.updateLoadStatus(percentComplete=95, statusText="Switching to launch screen...")
 
     # Switch to the launch screen

--- a/Application/application.py
+++ b/Application/application.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     models = []
     loadScreen.updateLoadStatus(percentComplete=60, statusText="Initializing Vilt model\nThis step will take longer the first time this application loads.")
     models.append((setupViltTransformer()))
-    loadScreen.updateLoadStatus(percentComplete=80, statusText="Initializing LxMERT model\nThis step will take longer the first time this application loads.")
+    loadScreen.updateLoadStatus(percentComplete=80, statusText="Initializing both LxMERT models\nThis step will take longer the first time this application loads.")
     models.append((setupLxmertTransformer()))
     loadScreen.updateLoadStatus(percentComplete=95, statusText="Switching to launch screen...")
 

--- a/Application/config.json
+++ b/Application/config.json
@@ -1,0 +1,38 @@
+{
+  "architectures": [
+    "LxmertForQuestionAnswering"
+  ],
+  "attention_probs_dropout_prob": 0.1,
+  "hidden_act": "gelu",
+  "hidden_dropout_prob": 0.1,
+  "hidden_size": 768,
+  "initializer_range": 0.02,
+  "intermediate_size": 3072,
+  "l_layers": 9,
+  "layer_norm_eps": 1e-12,
+  "max_position_embeddings": 512,
+  "model_type": "lxmert",
+  "num_attention_heads": 12,
+  "num_attr_labels": 400,
+  "num_hidden_layers": {
+    "cross_encoder": 5,
+    "language": 9,
+    "vision": 5
+  },
+  "num_object_labels": 1600,
+  "num_qa_labels": 3129,
+  "r_layers": 5,
+  "task_mask_lm": true,
+  "task_matched": true,
+  "task_obj_predict": true,
+  "task_qa": true,
+  "type_vocab_size": 2,
+  "visual_attr_loss": true,
+  "visual_feat_dim": 2048,
+  "visual_feat_loss": true,
+  "visual_loss_normalizer": 6.67,
+  "visual_obj_loss": true,
+  "visual_pos_dim": 4,
+  "vocab_size": 30522,
+  "x_layers": 5
+}

--- a/Application/utils.py
+++ b/Application/utils.py
@@ -83,7 +83,8 @@ def setupLxmertTransformer():
 
     # Define the model
     lxmert_tokenizer = LxmertTokenizer.from_pretrained("unc-nlp/lxmert-base-uncased")
-    lxmert_vqa = LxmertForQuestionAnswering.from_pretrained("lxmert_best_model.pth")
+    # https://huggingface.co/docs/transformers/v4.26.1/en/main_classes/model#transformers.PreTrainedModel.from_pretrained
+    lxmert_vqa = LxmertForQuestionAnswering.from_pretrained()
 
     # Setup Faster RCNN Model for visual embeddings (backbone)
     frcnn_cfg = Config.from_pretrained("unc-nlp/frcnn-vg-finetuned")

--- a/Application/utils.py
+++ b/Application/utils.py
@@ -83,17 +83,13 @@ def setupLxmertTransformer():
 
     # Define the model
     lxmert_tokenizer = LxmertTokenizer.from_pretrained("unc-nlp/lxmert-base-uncased")
-
-    # *** Original model
     lxmert_vqa = LxmertForQuestionAnswering.from_pretrained("unc-nlp/lxmert-vqa-uncased") 
-    lxmert_vqa_finetuned = LxmertForQuestionAnswering.from_pretrained(pretrained_model_name_or_path='lxmert_best_model.pth', config='config.json')
 
     # Setup Faster RCNN Model for visual embeddings (backbone)
     frcnn_cfg = Config.from_pretrained("unc-nlp/frcnn-vg-finetuned")
     frcnn = GeneralizedRCNN.from_pretrained("unc-nlp/frcnn-vg-finetuned", config=frcnn_cfg)
     image_preprocess = Preprocess(frcnn_cfg)
 
-    # add lxmert_vqa_finetuned to this list. 
     return lxmert_tokenizer, lxmert_vqa, frcnn_cfg, frcnn, image_preprocess
 
 def setupLxmertTransformer_finetuned():

--- a/Application/utils.py
+++ b/Application/utils.py
@@ -83,7 +83,7 @@ def setupLxmertTransformer():
 
     # Define the model
     lxmert_tokenizer = LxmertTokenizer.from_pretrained("unc-nlp/lxmert-base-uncased")
-    lxmert_vqa = LxmertForQuestionAnswering.from_pretrained("unc-nlp/lxmert-vqa-uncased")
+    lxmert_vqa = LxmertForQuestionAnswering.from_pretrained("lxmert_best_model.pth")
 
     # Setup Faster RCNN Model for visual embeddings (backbone)
     frcnn_cfg = Config.from_pretrained("unc-nlp/frcnn-vg-finetuned")

--- a/Application/utils.py
+++ b/Application/utils.py
@@ -84,7 +84,7 @@ def setupLxmertTransformer():
     # Define the model
     lxmert_tokenizer = LxmertTokenizer.from_pretrained("unc-nlp/lxmert-base-uncased")
     # https://huggingface.co/docs/transformers/v4.26.1/en/main_classes/model#transformers.PreTrainedModel.from_pretrained
-    lxmert_vqa = LxmertForQuestionAnswering.from_pretrained()
+    lxmert_vqa = LxmertForQuestionAnswering.from_pretrained(pretrained_model_name_or_path='lxmert_best_model.pth', config='config.json')
 
     # Setup Faster RCNN Model for visual embeddings (backbone)
     frcnn_cfg = Config.from_pretrained("unc-nlp/frcnn-vg-finetuned")

--- a/Application/utils.py
+++ b/Application/utils.py
@@ -93,7 +93,8 @@ def setupLxmertTransformer():
     frcnn = GeneralizedRCNN.from_pretrained("unc-nlp/frcnn-vg-finetuned", config=frcnn_cfg)
     image_preprocess = Preprocess(frcnn_cfg)
 
-    return lxmert_tokenizer, lxmert_vqa, lxmert_vqa_finetuned, frcnn_cfg, frcnn, image_preprocess
+    # add lxmert_vqa_finetuned to this list. 
+    return lxmert_tokenizer, lxmert_vqa, frcnn_cfg, frcnn, image_preprocess
 
 def runFRCNN(image, image_preprocess, frcnn, frcnn_cfg):
     # Save a temporary copy of the image for the model
@@ -173,6 +174,8 @@ def predictLxmert(lxmert_tokenizer, lxmert_vqa, frcnn_cfg, frcnn, image_preproce
         output_attentions=False,
     )
 
+    # inference on lxmert fine tuned model
+
     # output_vqa_fine_tuned = lxmert_vqa_finetuned(
     #     input_ids=inputs.input_ids,
     #     attention_mask=inputs.attention_mask,
@@ -184,10 +187,15 @@ def predictLxmert(lxmert_tokenizer, lxmert_vqa, frcnn_cfg, frcnn, image_preproce
 
     # Get top predicted answer index
     pred_vqa = output_vqa["question_answering_score"].argmax(-1)
+
     # pred_vqa_finetuned = output_vqa_fine_tuned["question_answering_score"].argmax(-1)
 
     # Get Top Answers
     top_predictions = getTopPredictions(output_vqa["question_answering_score"][0], vqa_answers)
+
+    # top answers for output_vqa_fine_tuned
+    # top_predictions = getTopPredictions(output_vqa_fine_tuned["question_answering_score"][0], vqa_answers)
+
     
     # Obtain the tokens used as input
     encoded_tokens = inputs['input_ids'].tolist()[0]

--- a/Application/utils.py
+++ b/Application/utils.py
@@ -84,17 +84,16 @@ def setupLxmertTransformer():
     # Define the model
     lxmert_tokenizer = LxmertTokenizer.from_pretrained("unc-nlp/lxmert-base-uncased")
 
-    # *** OLD MODEL. Load this if no local model is present.
-    # lxmert_vqa = LxmertForQuestionAnswering.from_pretrained("unc-nlp/lxmert-vqa-uncased") 
-    
-    lxmert_vqa = LxmertForQuestionAnswering.from_pretrained(pretrained_model_name_or_path='lxmert_best_model.pth', config='config.json')
+    # *** Original model
+    lxmert_vqa = LxmertForQuestionAnswering.from_pretrained("unc-nlp/lxmert-vqa-uncased") 
+    lxmert_vqa_finetuned = LxmertForQuestionAnswering.from_pretrained(pretrained_model_name_or_path='lxmert_best_model.pth', config='config.json')
 
     # Setup Faster RCNN Model for visual embeddings (backbone)
     frcnn_cfg = Config.from_pretrained("unc-nlp/frcnn-vg-finetuned")
     frcnn = GeneralizedRCNN.from_pretrained("unc-nlp/frcnn-vg-finetuned", config=frcnn_cfg)
     image_preprocess = Preprocess(frcnn_cfg)
 
-    return lxmert_tokenizer, lxmert_vqa, frcnn_cfg, frcnn, image_preprocess
+    return lxmert_tokenizer, lxmert_vqa, lxmert_vqa_finetuned, frcnn_cfg, frcnn, image_preprocess
 
 def runFRCNN(image, image_preprocess, frcnn, frcnn_cfg):
     # Save a temporary copy of the image for the model
@@ -174,8 +173,18 @@ def predictLxmert(lxmert_tokenizer, lxmert_vqa, frcnn_cfg, frcnn, image_preproce
         output_attentions=False,
     )
 
+    # output_vqa_fine_tuned = lxmert_vqa_finetuned(
+    #     input_ids=inputs.input_ids,
+    #     attention_mask=inputs.attention_mask,
+    #     visual_feats=features,
+    #     visual_pos=normalized_boxes,
+    #     token_type_ids=inputs.token_type_ids,
+    #     output_attentions=False,
+    # )
+
     # Get top predicted answer index
     pred_vqa = output_vqa["question_answering_score"].argmax(-1)
+    # pred_vqa_finetuned = output_vqa_fine_tuned["question_answering_score"].argmax(-1)
 
     # Get Top Answers
     top_predictions = getTopPredictions(output_vqa["question_answering_score"][0], vqa_answers)

--- a/Application/utils.py
+++ b/Application/utils.py
@@ -83,7 +83,10 @@ def setupLxmertTransformer():
 
     # Define the model
     lxmert_tokenizer = LxmertTokenizer.from_pretrained("unc-nlp/lxmert-base-uncased")
-    # https://huggingface.co/docs/transformers/v4.26.1/en/main_classes/model#transformers.PreTrainedModel.from_pretrained
+
+    # *** OLD MODEL. Load this if no local model is present.
+    # lxmert_vqa = LxmertForQuestionAnswering.from_pretrained("unc-nlp/lxmert-vqa-uncased") 
+    
     lxmert_vqa = LxmertForQuestionAnswering.from_pretrained(pretrained_model_name_or_path='lxmert_best_model.pth', config='config.json')
 
     # Setup Faster RCNN Model for visual embeddings (backbone)


### PR DESCRIPTION
## Please read the following notes carefully:

### How to run this?

- An LxMERT fine-tuned model has been uploaded to the sharepoint, in a new folder named "lxmert_tuned_models." Please place the .pth file in the same directory as application/utils.py

- To most accurately gauge the performance of the fine-tuned model, be sure to clear your cache (somewhere in C:\Users\\{name}\\.cache; check the console for exact directory and folder) when trying to load the fine-tuned model; otherwise, it will load a cached LxMERT version (unc-nlp/lxmert-vqa-uncased). 

### Possible poor performance:

While unlikely, it is possible that the performance of the fine-tuned VQA model will be dismal, as the architecture of the model does not exactly match the architecture in the config.js file. As a result, not all of the weights are used during inference. My next priority, alongside fine-tuning with a greater amount of data, is to export the exact config.js file so that all of the weights of this fine-tuned model can be used. 

The poor performance _will not_ be an expected part of our training process and should resolve itself once the architecture laid out in config.json matches the architecture of the model. **This may take some time to resolve**. In the meantime, however, fine-tuning and training is still possible.

## Training notes (mostly for Joe and for meetings/presentations):

### Training information
Fine-tuning took place on an RTX 3070 Ti consisting of a tiny generalized dataset of 512 images. 
The process took about 120 seconds to complete.  
9 llayers
5 xlayers
5 rlayers
batch size of 32, learning rate of 5e-5, 10 epochs.

### Further details and memory solutions
The model was already pretrained and can be acquired from: http://nlp.cs.unc.edu/data/model_LXRT.pth
Memory fragmentation was a problem, as the 3070 Ti only has 8GB of VRAM. As such, the following possibilities were explored:
- Reduced batch size
- Offloaded model to CPU
- Different optimizers were used
- Exclusively CPU training (about 20s per epoch with 512 images; certainly doable for small datasets).
- PYTORCH_CUDA_ALLOC_CONF parameter used and set to 324MB to eliminate fragmentation. (solution currently in use)

### Misc. notes:

- I did not test the performance of this pull request. The DroneVQA software is not linking to the simulation environment on my machine, so I created this pull request while I trouble shoot it, so that you all can test it alongside me and provide feedback.

- GPU acceleration works fine. If CUDA is not available for you, you can map it to CPU when loading the model.

