### PR TITLE
Visualization PNGs Export With Names

### DIFF
--- a/Application/ModelPredictionUtils.py
+++ b/Application/ModelPredictionUtils.py
@@ -70,9 +70,12 @@ def predictVilt(model, processor, question, image):
 
     # Generate Names for Each Visualization
     # Order: Combined, token 1, token 2, ...., token n
+    # Naming Restriction: These visualization names will dicate the filenames of exported visualization PNGs. Ensure
+    #                     that visualization name structure remains compliant with OS filename symbol restrictions.
+
     visualization_names = ["Combined Attention Patches"]
     visualization_names.extend(
-        [f"Token {id}: {token}" for id, token in enumerate(decoded_tokens)]
+        [f"Token {id} - \'{token}\'" for id, token in enumerate(decoded_tokens)]
     )
    
     results = PredictionResults(question=question, image=image,

--- a/Application/ModelPredictionUtils.py
+++ b/Application/ModelPredictionUtils.py
@@ -244,11 +244,9 @@ def predictLxmert(lxmert_tokenizer, lxmert_vqa, frcnn_cfg, frcnn, image_preproce
     attention_rollout_image_scores = torch.sum(R_t_i, dim=0)
     image_scores.append(attention_rollout_image_scores)
 
-    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB) # Pre-format the image for visualization outputs
     for image_score in image_scores:
         path = create_image_vis(image, image_score, output_dict, r"./LxmertVisualization.jpg")
         visualization = cv2.imread(path)
-        visualization = cv2.cvtColor(visualization, cv2.COLOR_BGR2RGB)
         os.remove(path) # Remove the file after we read it
         visualizations.append(visualization)
     


### PR DESCRIPTION
## Summary of Changes
- Exported visualization PNGs are saved with proper names
- System time is saved with a leading year value to avoid lifetime duplicates and maintain export sorting between years
- Visualization names are filtered with using a string replace() for characters that cannot be included in a file name on Windows, including the symbols... /\:*?"<>|

## ViLT Export Example, with invalid symbol replacement demonstration:
![image](https://user-images.githubusercontent.com/59713234/226254515-cf7c8f5e-d354-4018-826c-a84419816203.png)

## LXMERT Export Example, where invalid symbols have no effect on PNG file naming:
![image](https://user-images.githubusercontent.com/59713234/226254399-e79b0a8b-be30-4500-9c4e-525092a03fbc.png)

